### PR TITLE
自習：色々変更してみる

### DIFF
--- a/work/app/Todo.php
+++ b/work/app/Todo.php
@@ -105,6 +105,22 @@ class Todo
 
     private function purge()
     {
+        // フロント側のチェック済みidの配列
+        $appCheckedIds = array_map(
+            function ($value) {return (int) $value;},
+            explode(',', filter_input(INPUT_POST, 'appCheckedIds'))
+        );
+        // DB側のis_doneがtrueであるidの配列
+        $dbIsDoneIds = $this->pdo->query(
+            "SELECT id FROM todos WHERE is_done = 1"
+        )->fetchAll(\PDO::FETCH_COLUMN);
+        // 差異があれば404を返して処理を終了
+        $diff = array_diff($dbIsDoneIds, $appCheckedIds);
+        if (count($appCheckedIds) !== count($dbIsDoneIds) || count($diff)) {
+            header('HTTP', true, 404);
+            exit;
+        }
+        // 差異がなければDBを削除する
         $this->pdo->query("DELETE FROM todos WHERE is_done = 1");
     }
 }

--- a/work/app/Todo.php
+++ b/work/app/Todo.php
@@ -25,9 +25,7 @@ class Todo
                     echo json_encode(['id' => $id]);
                     break;
                 case 'toggle':
-                    $isDone = $this->toggle();
-                    header('Content-Type: application/json');
-                    echo json_encode(['is_done' => $isDone]);
+                    $this->toggle();
                     break;
                 case 'delete':
                     $this->delete();
@@ -77,19 +75,18 @@ class Todo
             header('HTTP', true, 404);
             exit;
         }
+        // フロント側のチェック状態にDBを合わせる
+        $checkFlag = filter_input(INPUT_POST, 'checkFlag', FILTER_VALIDATE_BOOLEAN);
 
         $stmt = $this->pdo->prepare(
             "UPDATE todos
-        SET is_done = NOT is_done
+        SET is_done = :checkFlag
         WHERE id = :id"
         );
+        $stmt->bindValue('checkFlag', $checkFlag, \PDO::PARAM_BOOL);
         $stmt->bindValue('id', $id, \PDO::PARAM_INT);
         $stmt->execute();
 
-        // todoが存在した場合、該当のidの最新のis_doneの値は
-        // DB更新前に取得した$todoのis_doneを反転したものと等しい
-        // MySQLでは真偽値は1-0で管理しているためtrue-falseに変換する
-        return (boolean) !$todo->is_done;
     }
 
     private function delete()

--- a/work/public/js/main.js
+++ b/work/public/js/main.js
@@ -59,27 +59,27 @@
 
   function toggleTodo(target) {
     const id = target.parentNode.dataset.id;
+    // checkedの情報を送る
+    const checkFlag = target.checked;
+    console.log(checkFlag);
     fetch('?action=toggle', {
       method: 'POST',
       body: new URLSearchParams({
         id,
         token,
+        checkFlag,
       }),
     })
       .then((res) => {
         if (!res.ok) {
-          throw new Error('該当のtodoはすでに削除されています');
-        }
-        return res.json();
-      })
-      .then((json) => {
-        if (target.checked !== json.is_done) {
-          alert('このtodoはアップデートされています。画面を更新します');
-          target.checked = json.is_done;
+          throw new Error('todo deleted already');
         }
       })
       .catch((err) => {
-        window.alert(err.message);
+        console.error(err.message);
+        window.alert(
+          '該当のtodoはすでに削除されています。画面を最新のデータに更新します。'
+        );
         location.reload();
       });
   }

--- a/work/public/js/main.js
+++ b/work/public/js/main.js
@@ -66,22 +66,22 @@
         token,
       }),
     })
-    .then(res => {
-      if (!res.ok) {
-        throw new Error('該当のtodoはすでに削除されています');
-      }
-      return res.json()
-    })
-    .then(json => {
-      if (target.checked !== json.is_done) {
-        alert('このtodoはアップデートされています。画面を更新します');
-        target.checked = json.is_done;
-      }
-    })
-    .catch(err => {
-      window.alert(err.message);
-      location.reload();
-    });
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error('該当のtodoはすでに削除されています');
+        }
+        return res.json();
+      })
+      .then((json) => {
+        if (target.checked !== json.is_done) {
+          alert('このtodoはアップデートされています。画面を更新します');
+          target.checked = json.is_done;
+        }
+      })
+      .catch((err) => {
+        window.alert(err.message);
+        location.reload();
+      });
   }
 
   function deleteTodo(target) {
@@ -128,15 +128,10 @@
       [/"/g, '&quot;'],
       [/'/g, '&#039;'],
     ];
-    let escapeStr = str;
-    for (const [reg, entity] of regSet) {
-      escapeStr = escapeStr.replace(reg, entity);
-    }
-    return escapeStr;
-    // return regSet.reduce(
-    //   (escapeStr, [reg, entity]) => escapeStr.replace(reg, entity),
-    //   str
-    // );
+    return regSet.reduce(
+      (escapeStr, [reg, entity]) => escapeStr.replace(reg, entity),
+      str
+    );
   }
 
   function element(strings, ...values) {


### PR DESCRIPTION
## 効率的なコードを書くことに挑戦する

- [x] エスケープの処理をfor文からreduceに変更してみる

## 複数ウィンドウ処理でのデータの整合性について考える

dotinstallでは複数ウィンドウで操作した結果DBとフロント側のデータの整合性が取れなくなった場合、DB側を優先してフロント側を合わせるような実装をしていた。
しかし個人的に使用する側として考えた場合、DB側を優先して、自分が今操作しているフロント側から予想されるのとは異なる動作をすることは、使い勝手がいいとはあまり思えない。
フロントの表示側にできるだけ合わせていく方向性で考えたい。
フロント側のデータを見て、DB側を合わせるやり方に問題がないか、検証も含めて試してみる。

- [x] 複数ウィンドウのチェック→チェックの際の修正をDB優先からフロント側優先にする
- [x] 複数ウィンドウでチェック後Purgeの時のDBとフロント側の整合性が取れなくなった場合の処理を考える